### PR TITLE
Invert standalone paramter

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -98,7 +98,7 @@ jobs:
       matrix:
         job:
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             linker: '-C linker=aarch64-linux-gnu-gcc'
           # - target: aarch64-unknown-linux-musl
           #   os: ubuntu-20.04
@@ -111,8 +111,8 @@ jobs:
           # - target: arm-unknown-linux-musleabihf
           #   linker: '-C linker=arm-linux-gnueabihf-gcc'
           #   os: ubuntu-20.04
-          - target: i686-pc-windows-msvc
-            os: windows-2019
+          # - target: i686-pc-windows-msvc
+          #   os: windows-2019
           # - target: i686-unknown-linux-gnu
           #   os: ubuntu-20.04
           # - target: i686-unknown-linux-musl

--- a/client-rs/justfile
+++ b/client-rs/justfile
@@ -2,4 +2,4 @@ default:
     @just --list
 
 run:
-    cargo run -- --address unix:../.asciidoctor-server.sock
+    cargo run -- --address unix:../.asciidoctor-server.sock --no-header-footer

--- a/client-rs/src/main.rs
+++ b/client-rs/src/main.rs
@@ -21,6 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         input: _,
         max_timeout,
     } = argh::from_env();
+    let standalone = !no_header_footer;
     let addy = server_address.clone();
     let backoff = ExponentialBuilder::default()
         .with_min_delay(Duration::from_millis(125))
@@ -28,7 +29,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_max_delay(Duration::from_secs(max_timeout))
         .with_jitter();
     let endpoint = Endpoint::try_from("http://[::]:50051")?;
-    std::fs::read_to_string("/etc/os-release").map_err(|_| "Failed to read /etc/os-release")?;
     cfg_if!(
         if #[cfg(unix)] {
             let connector = move |_: Uri| {
@@ -65,7 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         attributes,
         backend,
         extensions,
-        standalone: no_header_footer,
+        standalone,
     };
 
     let convert = || async {


### PR DESCRIPTION
The asciidoctor api option "Standalone" and cli flag "no-header-footer" are inverses of each other. The flag should be inverted when passing between them